### PR TITLE
Modernize Python 2 cod to prepare for Python 3

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,4 +1,10 @@
-#!/usr/bin/python
+#!/usr/bin/env python
+from __future__ import print_function
+
+import multiprocessing
+import os
+import threading
+
 from util.ConfigUtils import getBaseConfig
 from util.CrimeTracker import getCrimeList
 from util.DnsBlUtils import getBLList
@@ -11,15 +17,9 @@ from util.PayloadUtils import getPLList
 from util.ShodanUtils import getShodanList
 from util.VxVault import getVXList
 
-
-import multiprocessing
-import os
-import threading
-
-
-#       .__    _______                        __         .__       
-#______ |  |__ \   _  \   ____   ____  __ ___/  |________|__|____  
-#\____ \|  |  \/  /_\  \ /    \_/ __ \|  |  \   __\_  __ \  \__  \ 
+#       .__    _______                        __         .__
+#______ |  |__ \   _  \   ____   ____  __ ___/  |________|__|____
+#\____ \|  |  \/  /_\  \ /    \_/ __ \|  |  \   __\_  __ \  \__  \
 #|  |_> >   Y  \  \_/   \   |  \  ___/|  |  /|  |  |  | \/  |/ __ \_
 #|   __/|___|  /\_____  /___|  /\___  >____/ |__|  |__|  |__(____  /
 #|__|        \/       \/     \/     \/                           \/
@@ -31,14 +31,14 @@ import threading
 
 rootDir = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(rootDir, 'res', 'banner.txt'), 'r') as banner:
-        print banner.read()
+        print(banner.read())
 
 
 logging = getModuleLogger(__name__)
 baseConfig = getBaseConfig(rootDir)
 
 
-def main(): 
+def main():
     if not os.path.exists(baseConfig.outputFolder):
         os.makedirs(baseConfig.outputFolder)
 
@@ -73,7 +73,7 @@ def main():
             for web in webs:
                 web.terminate()
                 web.join()
-                
+
     else:
         logging.info('Spawning single ph0neutria spider. Press CTRL+C to terminate.')
         startMalc0de()
@@ -114,10 +114,10 @@ def startOSINT():
 
     if len(pl_list) > 0 and baseConfig.multiProcess.lower() == 'no':
         fetchOSINT(pl_list)
-        
+
     if len(pl_list) > 0 and baseConfig.multiProcess.lower() == 'no':
         fetchOSINT(pl_list)
-        
+
     crime_list = getCrimeList()
 
     if len(crime_list) > 0 and baseConfig.multiProcess.lower() == 'yes':
@@ -137,7 +137,7 @@ def startOSINT():
 
     if len(otx_list) > 0 and baseConfig.multiProcess.lower() == 'no':
         fetchOSINT(otx_list)
-        
+
     shodan_list = getShodanList()
 
     if len(shodan_list) > 0 and baseConfig.multiProcess.lower() == 'yes':

--- a/util/ShodanUtils.py
+++ b/util/ShodanUtils.py
@@ -1,20 +1,13 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
+import datetime
+import os
+
+import shodan
 from ConfigUtils import getBaseConfig
 from LogUtils import getModuleLogger
 from MachineUtils import getSignificantItems
-from requests_toolbelt.multipart.encoder import MultipartEncoder
 from VirusTotal import getUrlsForIp
-
-
-import datetime
-import json
-import os
-import requests
-import shodan
-import sys
-import time
-
 
 cDir = os.path.dirname(os.path.realpath(__file__))
 rootDir = os.path.abspath(os.path.join(cDir, os.pardir))
@@ -58,7 +51,7 @@ def queryShodan():
         else:
             return []
 
-    except shodan.APIError, e:
+    except shodan.APIError as e:
         logging.info('Error: {0}'.format(e))
         return []
 


### PR DESCRIPTION
Minor modifications to be syntax compatible with both Python 2 and 3.
* print() is a function in Python 3
* Old style exceptions --> new style for Python 3
* Ran isort on the imports and removed unused imports
* Remove shebang hardcoding of the path to Python