### PR TITLE
dir viper does not exist in /opt directory

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,8 @@ make install
 cd /tmp
 rm -rf yara
 pip3 install yara-python
-git clone https://github.com/viper-framework/viper
 cd /opt
+git clone https://github.com/viper-framework/viper
 cd viper
 pip3 install -r requirements.txt
 # Workaround for requests SSL errors (https://github.com/requests/requests/issues/3006):


### PR DESCRIPTION
Cloning into 'viper'...
./install.sh: line 31: cd: viper: No such file or directory

change dir to /opt before cloning.