### PR TITLE
New URLHause URL

### DIFF
--- a/core/plugins/urlhaus.py
+++ b/core/plugins/urlhaus.py
@@ -41,7 +41,7 @@ def get_malwareurl_list():
         LOGGING.info('Fetching latest URLhaus list...')
 
         request = requests.get(
-            'https://urlhaus.abuse.ch/downloads/csv/',
+            'https://urlhaus.abuse.ch/downloads/csv_online/',
             headers=user_agent)
 
         if request.status_code == 200:


### PR DESCRIPTION
The old URL now points to a zip compressed file. URL updated to use the URLhaus database dump (CSV) containing only online (active) malware URLs. The format is the same.